### PR TITLE
doc: add missing backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `package.json` file contains the following keys:
 
 <small>This is a copy of the `microbundle` documentation.</small>
 
-When you build your project using `microbundle, three different file formats are generated:
+When you build your project using `microbundle`, three different file formats are generated:
 
 -   <kbd>.umd.js</kbd>: A Universal Module Definition (UMD) file format that works in different module systems, including AMD, CommonJS, and global scripts.
 


### PR DESCRIPTION
adds a missing backtick to the README.md. Sorry for the tiny pull request but it was bothering me <3